### PR TITLE
Update for current Dialyxir, Travis-CI, S3 practices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# The directory Mix will write compiled artifacts to.
+/_build
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover
+
+# The directory Mix downloads your dependencies sources to.
+/deps
+
+# Where 3rd-party dependencies like ExDoc output generated docs.
+/doc
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore hidden and swap files
+.*
+*~

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,37 +1,32 @@
 language: elixir
 elixir:
-  - 1.0.0
-  - 1.0.1
-  - 1.0.2
-  - 1.0.3
-  - 1.0.4
-  - 1.0.5
-  - 1.1.0
-  - 1.1.1
-  - 1.2.0
-  - 1.3.0
-  - 1.3.1
-  - 1.3.2
   - 1.3.3
+  - 1.3.4
   - 1.4.0-rc.0
   - 1.4.0-rc.1
+  - 1.4.0
+  - 1.4.1
+  - 1.4.2
 otp_release:
+  - 19.2
+  - 19.1
   - 19.0
   - 18.1
   - 18.0
-  - 17.4
+addons:
+  artifacts:
+    debug: true
+    paths:
+      - $(ls plts/*.plt)
+    working_dir: plts
+    target_paths:
+      - travis_elixir_plts
 before_script:
   - export PATH=`pwd`/elixir/bin:$PATH
-  - git clone git://github.com/jeremyjh/dialyxir.git
+  - git clone https://github.com/jeremyjh/dialyxir.git
   - cd dialyxir
-  - mix deps.get
-  - mix archive.build
-  - mix archive.install --force
+  - MIX_ENV=prod mix do compile, archive.build
+  - MIX_ENV=prod mix archive.install --force
   - cd ..
-  - mix local.hex --force
-  - mix deps.get --only test
 script:
-  - MIX_ENV=test mix dialyzer.plt
-after_script:
-  - curl -sL https://raw.githubusercontent.com/travis-ci/artifacts/master/install | bash
-  - /home/travis/bin/artifacts upload --key $ARTIFACTS_KEY --secret $ARTIFACTS_SECRET --bucket $ARTIFACTS_BUCKET --target-paths travis_elixir_plts plts
+  - MIX_ENV=test mix dialyzer --plt

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ instructions.
 
 ## Usage
 You must have an Amazon S3 account with a valid bucket name. Make sure that the
-bucket was created in the "US Standard" region, or you'll encounter errors.
+bucket was created in the "US East (N. Virginia)" region, or you'll encounter
+errors.
 
 1. Fork this repository.
 2. Set the following ENV vars for your fork on Travis:

--- a/mix.exs
+++ b/mix.exs
@@ -8,10 +8,9 @@ defmodule ExTwilio.Mixfile do
      name: "Travis PLT Generator",
      source_url: "https://github.com/danielberkompas/ex_twilio",
      dialyzer: [
-       plt_file: "plts/#{plt_filename}",
-       flags: ["--no_native"]
+       plt_file: "plts/#{plt_filename()}",
      ],
-     deps: deps]
+     deps: deps()]
   end
 
   def application do
@@ -23,7 +22,7 @@ defmodule ExTwilio.Mixfile do
   end
 
   defp plt_filename do
-    "elixir-#{System.version}_#{otp_release}.plt"
+    "elixir-#{System.version}_#{otp_release()}.plt"
   end
 
   defp otp_release do


### PR DESCRIPTION
* Remove OTP<18, Elixir<1.3.3 (dialyxir needs Elixir>1.3.2).
* Fix dialyxir invocation (`dialyzer.plt` task was removed).
* Drop '--no_native' flag (not recognized by `:dialyzer.run/1`).
* Make dialyxir archive install match dialyxir README.
* Add empty parens in `mix.exs` to avoid warnings in Elixir 1.4.
* Add new Elixir and OTP versions to `.travis.yml`.
* Update README: change 'US Standard' to 'US East (N. Virginia)'.
* Add `.gitignore` (to ignore `_build` directory).