### PR TITLE
Add Elixir 1.4.4, OTP 20-rc1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ elixir:
   - 1.4.0
   - 1.4.1
   - 1.4.2
+  - 1.4.4
 otp_release:
   - 19.3
   - 19.2
@@ -14,6 +15,10 @@ otp_release:
   - 19.0
   - 18.1
   - 18.0
+matrix:
+  include:
+    - otp_release: 20.0-rc1
+      elixir: 1.4.4
 addons:
   artifacts:
     debug: true


### PR DESCRIPTION
Using `matrix.include` syntax to exclusively test OTP 20-rc1 with Elixir 1.4.4.  Despite loss of consistency, this seems better than running several jobs that are destined to fail.

A merge request with proof of work for the corresponding PLTs is forthcoming.